### PR TITLE
Add Tmuxinator config to dotfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/tmuxinator/*
+!/tmuxinator/dotfiles.yml

--- a/.zshrc.local
+++ b/.zshrc.local
@@ -4,6 +4,8 @@
 
 export PATH="$PATH:$HOME/.rvm/bin" # Add RVM to PATH for scripting
 
+export TMUXINATOR_CONFIG=$HOME/dotfiles-local/tmuxinator
+
 export NVM_DIR="/Users/freddyrangel/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ as possible.
 * NeoVim
 * GitHub Copilot
 * Node.js (for Copilot)
+* Tmuxinator
 
 ## Instructions
 

--- a/tmuxinator/dotfiles.yml
+++ b/tmuxinator/dotfiles.yml
@@ -1,0 +1,50 @@
+# /Users/freddyrangel/dotfiles-local/tmuxinator/dotfiles.yml
+
+name: dotfiles
+root: ~/dotfiles-local/
+
+# Optional tmux socket
+# socket_name: foo
+
+# Note that the pre and post options have been deprecated and will be replaced by
+# project hooks.
+
+# Project hooks
+
+# Runs on project start, always
+# on_project_start: command
+
+# Run on project start, the first time
+# on_project_first_start: command
+
+# Run on project start, after the first time
+# on_project_restart: command
+
+# Run on project exit ( detaching from tmux session )
+# on_project_exit: command
+
+# Run on project stop
+# on_project_stop: command
+
+# Runs in each window and pane before window/pane specific commands. Useful for setting up interpreter versions.
+# pre_window: rbenv shell 2.0.0-p247
+
+# Pass command line options to tmux. Useful for specifying a different tmux.conf.
+# tmux_options: -f ~/.tmux.mac.conf
+
+# Change the command to call tmux.  This can be used by derivatives/wrappers like byobu.
+# tmux_command: byobu
+
+# Specifies (by name or index) which window will be selected on project startup. If not set, the first window is used.
+# startup_window: editor
+
+# Specifies (by index) which pane of the specified window will be selected on project startup. If not set, the first pane is used.
+# startup_pane: 1
+
+# Controls whether the tmux session should be attached to automatically. Defaults to true.
+# attach: false
+
+windows:
+  - dotfiles-local: nvim
+  - thoughtbot-dotfiles: cd ~/dotfiles; nvim
+  - cli:


### PR DESCRIPTION
The beauty of tmux is that you can manage multiple projects and switch between them quickly. Tmuxinator is a tool I use to quickly setup a project so I can restart a project right away, the way I want it.

I want Tmuxinator to put the project configs inside dotfiles local.

I don't want project configs that are specific to my local environment added to version control. But dotfiles-local is always the same so I'll add that.