### PR TITLE
Tmux Quality of life

### DIFF
--- a/.zshrc.local
+++ b/.zshrc.local
@@ -13,7 +13,6 @@ export TERM=xterm-256color
 export GOPATH=$HOME/repositories/golang_packages
 
 alias ctags="`brew --prefix`/bin/ctags"
-alias tma="tmux attach -t $1"
 
 export ZSH=$HOME/.oh-my-zsh
 ZSH_THEME="norm"
@@ -78,3 +77,24 @@ fi
 export PYENV_ROOT="$HOME/.pyenv"
 command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"
+
+# Quality of Life stuff
+alias tma='tmux_attach_or_tmuxinator'
+function tmux_attach_or_tmuxinator() {
+  if [ $# -eq 0 ]; then
+    echo "Usage: tma <session_name>"
+    return 1
+  fi
+
+  local session_name="$1"
+  if tmux has-session -t "$session_name" 2>/dev/null; then
+    tmux attach-session -t "$session_name"
+  else
+    if command -v tmuxinator &> /dev/null; then
+      tmuxinator start "$session_name" || tmux new-session -s "$session_name"
+    else
+      echo "tmuxinator not found. Creating a new regular tmux session."
+      tmux new-session -s "$session_name"
+    fi
+  fi
+}


### PR DESCRIPTION
I added a function and alias called "tma" which will do a few things. When provided with a session name ("tma my-project") it will first try to attach to an existing tmux session with that name. If it doesn't exist, it will ask Tmuxinator to bootstrap a session with that name. If there isn't an existing config for that session name, then create a new regular tmux session with that name. Easy peasy. Saves a lot of typing.